### PR TITLE
Expanded usage of user input custom colour.

### DIFF
--- a/src/data/Options.ts
+++ b/src/data/Options.ts
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { useLocalStorage } from '../helpers/hooks'
 import queryStringData from '../helpers/queryStringData'
+import { cPrimary } from '../styling/constants'
 
 const query = queryStringData({
   valueKeys: ['draw'],
@@ -9,7 +10,7 @@ const query = queryStringData({
 
 export const initialOptions = {
   fixedScale: null as number | null,
-  drawColour: query.values.draw || 'lime',
+  drawColour: query.values.draw || cPrimary,
 }
 
 type GlobalOptions = typeof initialOptions

--- a/src/ui/CharacterSelector.tsx
+++ b/src/ui/CharacterSelector.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as _ from 'lodash'
+import Options from '../data/Options'
 
 import Character from '../data/Character'
 
@@ -15,12 +16,13 @@ export const CharacterSelector = ({
   availableKeys,
   selected,
   onSelect,
-}: CharacterSelectorProps) => (
-  <div
+}: CharacterSelectorProps) => {
+  const options = React.useContext(Options);
+  return <div
     style={{
       position: 'fixed',
       background: 'black',
-      color: 'lime',
+      color: options.drawColour,
       bottom: 0,
       right: 0,
     }}
@@ -31,7 +33,7 @@ export const CharacterSelector = ({
         key={key}
         style={{
           padding: '0.5rem',
-          border: key === selected ? '1px solid lime' : '1px solid black',
+          border: key === selected ? `1px solid ${options.drawColour}` : '1px solid black',
         }}
         onClick={() => onSelect(key)}
       >
@@ -39,6 +41,6 @@ export const CharacterSelector = ({
       </div>
     ))}
   </div>
-)
+}
 
 export default CharacterSelector

--- a/src/ui/Help.tsx
+++ b/src/ui/Help.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as _ from 'lodash'
 
-import { cPrimary, cMenuBg } from '../styling/constants'
+import { cMenuBg } from '../styling/constants'
 import Options, { SetOption, initialOptions } from '../data/Options'
 import customColorOptions from "../graphics/customColorOptions";
 

--- a/src/ui/PopupMenu.tsx
+++ b/src/ui/PopupMenu.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import * as _ from 'lodash'
 import { ignoreZoom } from '../helpers/styleSnippets'
-import { cMenuBg, cPrimary } from '../styling/constants'
+import { cMenuBg } from '../styling/constants'
+import Options from '../data/Options'
 
 type PopupMenuProps<T> = {
   position: { top: number; left: number } | null
@@ -10,8 +11,9 @@ type PopupMenuProps<T> = {
   onSelectItem?: (key: T) => void
 }
 
-export const PopupMenu = <T extends any>(props: PopupMenuProps<T>) =>
-  props.position ? (
+export const PopupMenu = <T extends any>(props: PopupMenuProps<T>) => {
+  const options = React.useContext(Options)
+  return props.position ? (
     <div
       style={{
         position: 'absolute',
@@ -26,10 +28,10 @@ export const PopupMenu = <T extends any>(props: PopupMenuProps<T>) =>
           style={ignoreZoom({
             padding: 2,
             background: cMenuBg,
-            borderColor: cPrimary,
+            borderColor: options.drawColour,
             borderStyle: 'solid',
             borderWidth: props.selectedItem === key ? 1 : 0,
-            color: 'lime',
+            color: options.drawColour,
           })}
           onClick={e => {
             props.onSelectItem && props.onSelectItem(key)
@@ -41,5 +43,6 @@ export const PopupMenu = <T extends any>(props: PopupMenuProps<T>) =>
       ))}
     </div>
   ) : null
+}
 
 export default PopupMenu


### PR DESCRIPTION
Noticed that the initial context menu (prior to the help modal) was still showing up as lime bordered regardless of user selected colour. 

This PR fixes that, whilst also hunting around for other remaining usages of 'lime'. Replaces many but not all with the user input. Any not replaced were on the basis of my perceived intent of the code. 
e.g. Not going to bother changing how the test code handles styling :-), or what colour 'friendlies' should be by default